### PR TITLE
Gather storage drives health status

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ metrics:
   - sensors
   - power
   - sel            # iDRAC only
+  - drives
 ```
 
 As shown in the example above, under `hosts` you can specify login information for individual hosts via their IP address, otherwise the exporter will attempt to use the login information under `default`. Under `metrics` you can select what kind of metrics that should be returned, as described in more detail below.
@@ -89,6 +90,12 @@ On iDRAC only, the system event log can also be exported. This is not exactly an
 ```
 idrac_sel_entry{id="1",message="The process of installing an operating system or hypervisor is successfully completed",component="BaseOSBoot/InstallationStatus",severity="OK"} 1631175352
 ```
+
+### Drive status
+Physical drive metrics could be exported. The value represents disk's health: 0 is OK, 1 is Warning, 2 is Critical, 10 is unknown status.
+
+idrac_drive_entry{manufacturer="TOSHIBA",model="AL14SXB30ENY",capacity="299439751168",state="StandbyOffline",name="Physical Disk 0:1:24",slot="24",mediatype="HDD"} 2
+idrac_drive_entry{manufacturer="TOSHIBA",model="AL14SXB30ENY",capacity="299439751168",state="Enabled",name="Physical Disk 0:1:25",slot="25",mediatype="HDD"} 0
 
 ## Prometheus Configuration
 For the situation where you have a single `idrac_exporter` and multiple iDRACs to query, the following `prometheus.yml` snippet can be used.

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,17 @@
+address: 127.0.0.1 # Listen address
+port: 9348 # Listen port
+timeout: 10 # HTTP timeout (in seconds) for Redfish API calls
+retries: 1 # Number of retries before a target is marked as unreachable
+hosts:
+  172.16.33.176:
+    username: root
+    password: calvin
+  default:
+    username: root
+    password: calvin
+metrics:
+  - system
+  - sensors
+  - power
+  - sel
+  - disks

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ var CollectSystem bool
 var CollectSensors bool
 var CollectSEL bool
 var CollectPower bool
+var CollectDrives bool
 
 func validateMetrics(name string) bool {
 	switch name {
@@ -63,6 +64,9 @@ func validateMetrics(name string) bool {
 		return true
 	case "sel":
 		CollectSEL = true
+		return true
+	case "drives":
+		CollectDrives = true
 		return true
 	}
 	return false

--- a/internal/promexporter/collector.go
+++ b/internal/promexporter/collector.go
@@ -74,6 +74,12 @@ func (c *metricsCollector) CollectMetrics() (string, error) {
 			return "", err
 		}
 	}
+	if config.CollectDrives {
+		err := c.RefreshStorage(c.store);
+		if err != nil {
+			return "", err
+		}
+	}
 
 	return c.store.Gather(), nil
 }

--- a/internal/promexporter/metrics.go
+++ b/internal/promexporter/metrics.go
@@ -224,9 +224,10 @@ func (s *MetricsStore) AddDriveEntry(name, mediatype, manufacturer, model string
 		"manufacturer": manufacturer,
 		"model":        model,
 		"capacity":     fmt.Sprint(capacitybytes),
+		"health":       health,
 		"state":        state,
 	}
-	s.appendMetric("drive_entry", float64(stateId), labels)
+	s.appendMetric("drive_health", float64(stateId), labels)
 }
 
 // Reset the accumulated string in the MetricsStore buffer

--- a/internal/promexporter/metrics.go
+++ b/internal/promexporter/metrics.go
@@ -205,6 +205,30 @@ func (s *MetricsStore) AddSelEntry(id string, message string, component string, 
 	s.appendMetric("sel_entry", float64(created.Unix()), labels)
 }
 
+func (s *MetricsStore) AddDriveEntry(name, mediatype, manufacturer, model string, slot, capacitybytes int, health, state string) {
+	var stateId int
+	switch health {
+	case "OK":
+		stateId = 0
+	case "Warning":
+		stateId = 1
+	case "Critical":
+		stateId = 2
+	default:
+		stateId = 10
+	}
+	labels := dict{
+		"name":         name,
+		"slot":         fmt.Sprint(slot),
+		"mediatype":    mediatype,
+		"manufacturer": manufacturer,
+		"model":        model,
+		"capacity":     fmt.Sprint(capacitybytes),
+		"state":        state,
+	}
+	s.appendMetric("drive_entry", float64(stateId), labels)
+}
+
 // Reset the accumulated string in the MetricsStore buffer
 func (s *MetricsStore) Reset() {
 	s.builder.Reset()

--- a/internal/redfish/model.go
+++ b/internal/redfish/model.go
@@ -133,6 +133,28 @@ type Fan struct {
 	UpperThresholdNonCritical interface{}   `json:"UpperThresholdNonCritical"`
 }
 
+type Drive struct {
+	Name             string `json:"Name"`
+	Description      string `json:"Description"`
+	MediaType        string `json:"MediaType"`
+	Manufacturer     string `json:"Manufacturer"`
+	Model            string `json:"Model"`
+	CapacityBytes    int    `json:"CapacityBytes"`
+	Status           Status `json:"Status"`
+	PhysicalLocation *struct {
+		PartLocation *struct {
+			LocationOrdinalValue int `json:"LocationOrdinalValue"`
+		} `json:"PartLocation"`
+	} `json:"PhysicalLocation"`
+}
+
+type ControllerResponse struct {
+	Name        string  `json:"Name"`
+	Description string  `json:"Description"`
+	Drives      []Odata `json:"Drives"`
+	Status      Status  `json:"Status"`
+}
+
 func (f *Fan) GetName() string {
 	if f.FanName != "" {
 		return f.FanName


### PR DESCRIPTION
PR title kinda says for itself, also explained in Readme.

In short, sole reason for me to look for the idrac_exporter was the need of healthchecking A LOT OF DRIVES. But there was no such feature, so - casually coded.

Few things i have to mention just in case:
1) I did not implement entire data models for what I added, i just used some fields that looked useful to me.
2) All Dell servers I have available are equipped with just one RAID controller. I'm neither aware if there are any with several controllers nor I have them, so this PR will gather data from the first controller only.