### PR TITLE
Added the possibility to reset the retry count of a target

### DIFF
--- a/cmd/idrac_exporter/handler.go
+++ b/cmd/idrac_exporter/handler.go
@@ -7,8 +7,9 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"github.com/mrlhansen/idrac_exporter/internal/logging"
+
 	"github.com/mrlhansen/idrac_exporter/internal/collector"
+	"github.com/mrlhansen/idrac_exporter/internal/logging"
 )
 
 const (
@@ -25,6 +26,19 @@ var gzipPool = sync.Pool{
 
 func HealthHandler(rsp http.ResponseWriter, req *http.Request) {
 	// just return a simple 200 for now
+}
+
+func ResetHandler(rsp http.ResponseWriter, req *http.Request) {
+	target := req.URL.Query().Get("target")
+	if target == "" {
+		logging.Errorf("Received request from %s without 'target' parameter", req.Host)
+		http.Error(rsp, "Query parameter 'target' is mandatory", http.StatusBadRequest)
+		return
+	}
+
+	logging.Debugf("Handling reset-request from %s for host %s", req.Host, target)
+
+	collector.Reset(target)
 }
 
 func MetricsHandler(rsp http.ResponseWriter, req *http.Request) {

--- a/cmd/idrac_exporter/main.go
+++ b/cmd/idrac_exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+
 	"github.com/mrlhansen/idrac_exporter/internal/config"
 	"github.com/mrlhansen/idrac_exporter/internal/logging"
 )
@@ -24,11 +25,12 @@ func main() {
 
 	http.HandleFunc("/metrics", MetricsHandler)
 	http.HandleFunc("/health", HealthHandler)
+	http.HandleFunc("/reset", ResetHandler)
 	bind := fmt.Sprintf("%s:%d", config.Config.Address, config.Config.Port)
 
 	logging.Infof("Server listening on %s", bind)
 
-	err := http.ListenAndServe(bind, nil);
+	err := http.ListenAndServe(bind, nil)
 	if err != nil {
 		logging.Fatal(err)
 	}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -2,11 +2,12 @@ package collector
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/mrlhansen/idrac_exporter/internal/config"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
-	"strings"
-	"sync"
 )
 
 var mu sync.Mutex
@@ -341,6 +342,16 @@ func (collector *Collector) Gather() (string, error) {
 	}
 
 	return collector.builder.String(), nil
+}
+
+// Resets an existing collector of the given target
+func Reset(target string) {
+	mu.Lock()
+	_, ok := collectors[target]
+	if ok {
+		collectors[target] = NewCollector()
+	}
+	mu.Unlock()
 }
 
 func GetCollector(target string) (*Collector, error) {


### PR DESCRIPTION
This change adds a `reset` endpoint which takes a `target` parameter and then resets the `retries` of that collector to 0 so that it will get fetched again next time.

This is helpful in case there are servers/idracs that are not always powered and when they are powered on, just this endpoint needs to be called and not the whole idrac_exporter needs to be restarted.