### PR TITLE
Alerts: Add dynamic calculation for severity label

### DIFF
--- a/grafana/alerts.yaml
+++ b/grafana/alerts.yaml
@@ -1,11 +1,20 @@
 groups:
-  - name: 'idrac-alerts'
+  - name: "idrac-alerts"
     rules:
       - alert: ServerNotHealthy
         expr: idrac_system_health{status!="OK"}
         for: 3m
         labels:
-          severity: critical
+          severity: >
+            {{- if $labels.status -}}
+            {{- if eq $labels.status "Warning" -}}
+            warning
+            {{- else if eq $labels.status "Critical" -}}
+            critical
+            {{- end -}}
+            {{- else -}}
+            critical
+            {{- end -}}
         annotations:
           description: Server {{ $labels.instance }} is not healthy, current status is {{ $labels.status }}.
           summary: Hardware server status is not healthy.


### PR DESCRIPTION
This calculates broadly used `severity` label to different values (warning or critical), depending on status label:
![image](https://github.com/mrlhansen/idrac_exporter/assets/122374011/400c1694-9769-4d32-be12-91366a405936)
