### PR TITLE
Add network-related metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ metrics:
   sel: false       # iDRAC only
   storage: false
   memory: false
+  network: false
 ```
 
 As shown in the example above, under `hosts` you can specify login information for individual hosts via their IP address, otherwise the exporter will attempt to use the login information under `default`. Under `metrics` you can select what kind of metrics that should be returned, as described in more detail below.
@@ -136,6 +137,16 @@ idrac_memory_module_info{ecc="MultiBitECC",id="DIMM.Socket.A2",manufacturer="Mic
 idrac_memory_module_health{id="DIMM.Socket.A2",status="OK"} 0
 idrac_memory_module_capacity_bytes{id="DIMM.Socket.A2"} 34359738368
 idrac_memory_module_speed_mhz{id="DIMM.Socket.A2"} 2400
+```
+
+### Network
+These metrics include health of network interfaces, as well as health, link speed, and link status for each of the network ports.
+
+```text
+idrac_network_interface_health{id="NIC.Embedded.1",status="OK"} 0
+idrac_network_port_health{id="NIC.Embedded.1-1",status="OK"} 0
+idrac_network_port_link_up{id="NIC.Embedded.1-1",status="Up"} 1
+idrac_network_port_speed_mbps{id="NIC.Embedded.1-1"} 1000
 ```
 
 ### Exporter

--- a/idrac.yml.template
+++ b/idrac.yml.template
@@ -13,3 +13,4 @@ metrics:
   sel: true        # iDRAC only
   storage: true
   memory: true
+  network: true

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -70,6 +70,12 @@ type Collector struct {
 	MemoryModuleHealth   *prometheus.Desc
 	MemoryModuleCapacity *prometheus.Desc
 	MemoryModuleSpeed    *prometheus.Desc
+
+	// Network
+	NetworkInterfaceHealth *prometheus.Desc
+	NetworkPortHealth      *prometheus.Desc
+	NetworkPortSpeed       *prometheus.Desc
+	NetworkPortLinkUp      *prometheus.Desc
 }
 
 func NewCollector() *Collector {
@@ -230,6 +236,26 @@ func NewCollector() *Collector {
 			"Speed of memory modules in Mhz",
 			[]string{"id"}, nil,
 		),
+		NetworkInterfaceHealth: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "network_interface", "health"),
+			"Health status for network interfaces",
+			[]string{"id", "status"}, nil,
+		),
+		NetworkPortHealth: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "network_port", "health"),
+			"Health status for network ports",
+			[]string{"id", "status"}, nil,
+		),
+		NetworkPortSpeed: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "network_port", "speed_mbps"),
+			"Link speed of ports in Mbps",
+			[]string{"id"}, nil,
+		),
+		NetworkPortLinkUp: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "network_port", "link_up"),
+			"Status of network ports, Up or Down",
+			[]string{"id", "status"}, nil,
+		),
 	}
 
 	collector.builder = new(strings.Builder)
@@ -271,6 +297,10 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.MemoryModuleHealth
 	ch <- collector.MemoryModuleCapacity
 	ch <- collector.MemoryModuleSpeed
+	ch <- collector.NetworkInterfaceHealth
+	ch <- collector.NetworkPortHealth
+	ch <- collector.NetworkPortSpeed
+	ch <- collector.NetworkPortLinkUp
 }
 
 func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
@@ -288,6 +318,12 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	}
 	if config.Config.Collect.Power {
 		err := collector.client.RefreshPower(collector, ch)
+		if err != nil {
+			collector.errors++
+		}
+	}
+	if config.Config.Collect.Network {
+		err := collector.client.RefreshNetwork(collector, ch)
 		if err != nil {
 			collector.errors++
 		}

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -19,6 +19,16 @@ func health2value(health string) float64 {
 	return 10
 }
 
+func linkstatus2value(status string) float64 {
+	switch status {
+	case "Down":
+		return 0
+	case "Up":
+		return 1
+	}
+	return 10
+}
+
 func (mc *Collector) NewSystemPowerOn(state string) prometheus.Metric {
 	var value float64
 	if state == "On" {
@@ -316,5 +326,47 @@ func (mc *Collector) NewMemoryModuleSpeed(id string, speed int) prometheus.Metri
 		prometheus.GaugeValue,
 		float64(speed),
 		id,
+	)
+}
+
+func (mc *Collector) NewNetworkInterfaceHealth(id, health string) prometheus.Metric {
+	value := health2value(health)
+	return prometheus.MustNewConstMetric(
+		mc.NetworkInterfaceHealth,
+		prometheus.GaugeValue,
+		value,
+		id,
+		health,
+	)
+}
+
+func (mc *Collector) NewNetworkPortHealth(id, health string) prometheus.Metric {
+	value := health2value(health)
+	return prometheus.MustNewConstMetric(
+		mc.NetworkPortHealth,
+		prometheus.GaugeValue,
+		value,
+		id,
+		health,
+	)
+}
+
+func (mc *Collector) NewNetworkPortSpeed(id string, speed int) prometheus.Metric {
+	return prometheus.MustNewConstMetric(
+		mc.NetworkPortSpeed,
+		prometheus.GaugeValue,
+		float64(speed),
+		id,
+	)
+}
+
+func (mc *Collector) NewNetworkPortLinkUp(id, status string) prometheus.Metric {
+	value := linkstatus2value(status)
+	return prometheus.MustNewConstMetric(
+		mc.NetworkPortLinkUp,
+		prometheus.GaugeValue,
+		value,
+		id,
+		status,
 	)
 }

--- a/internal/collector/model.go
+++ b/internal/collector/model.go
@@ -241,6 +241,23 @@ type Memory struct {
 	Status            Status `json:"Status"`
 }
 
+type NetworkInterface struct {
+	Id           string `json:"Id"`
+	Name         string `json:"Name"`
+	Description  string `json:"Description"`
+	Status       Status `json:"Status"`
+	NetworkPorts Odata  `json:"NetworkPorts"`
+}
+
+type NetworkPort struct {
+	Id           string `json:"Id"`
+	Name         string `json:"Name"`
+	Description  string `json:"Description"`
+	LinkStatus   string `json:"LinkStatus"`
+	CurrentSpeed int    `json:"CurrentLinkSpeedMbps"`
+	Status       Status `json:"Status"`
+}
+
 type SystemResponse struct {
 	IndicatorLED string `json:"IndicatorLED"`
 	Manufacturer string `json:"Manufacturer"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type RootConfig struct {
 		Power   bool `yaml:"power"`
 		Storage bool `yaml:"storage"`
 		Memory  bool `yaml:"memory"`
+		Network bool `yaml:"network"`
 	} `yaml:"metrics"`
 	Timeout       uint                   `yaml:"timeout"`
 	Retries       uint                   `yaml:"retries"`


### PR DESCRIPTION
This PR adds some metrics for the Network Interfaces, namely:
- health of network interfaces
- health of network ports
- link status (Up or Down) of network ports
- speed of network ports

Those can easily be extended since there is quite a lot of fields and parameters exported by iDRAC.
