### PR TITLE
Entrypoint: interpolate secrets correctly

### DIFF
--- a/idrac.yml.template
+++ b/idrac.yml.template
@@ -4,8 +4,8 @@ timeout: 60        # HTTP timeout (in seconds) for Redfish API calls
 retries: 10        # Number of retries before a target is marked as unreachable
 hosts:
   default:
-    username: $IDRAC_USERNAME
-    password: $IDRAC_PASSWORD
+    username: "$IDRAC_USERNAME"
+    password: "$IDRAC_PASSWORD"
 metrics:
   system: true
   sensors: true


### PR DESCRIPTION
The values for `hosts.default.{username,password}` should be strings. By adding quotes to the config template, we enforce this explicitly and mitigate errors that result from values that can be interpreted differently by YAML parsers.
