### PR TITLE
Add support for passing environment to container

### DIFF
--- a/charts/idrac-exporter/Chart.yaml
+++ b/charts/idrac-exporter/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.1.6"
+version: "0.1.7"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.2.2"

--- a/charts/idrac-exporter/templates/config.yaml
+++ b/charts/idrac-exporter/templates/config.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.idracConfig }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,4 +6,9 @@ metadata:
   labels:
     {{- include "idrac-exporter.labels" . | nindent 4 }}
 stringData:
+{{- if default .Values.idracConfigIsTemplate false }}
+  idrac.yml.template: {{ tpl .Values.idracConfig . | quote }}
+{{- else }}
   idrac.yml: {{ tpl .Values.idracConfig . | quote }}
+{{ end }}
+{{ end }}

--- a/charts/idrac-exporter/templates/deployment.yaml
+++ b/charts/idrac-exporter/templates/deployment.yaml
@@ -44,17 +44,31 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.env }}
+          env:
+          {{- range .Values.env }}
+            - {{ toYaml . | indent 14 | trim }}
+          {{- end }}
+          {{- end -}}
+          {{- if or (.Values.idracConfig) (.Values.volumeMounts) }}
           volumeMounts:
+          {{- end }}
+            {{- if .Values.idracConfig }}
             - mountPath: "/etc/prometheus"
               name: config
               readOnly: true
+            {{- end }}
           {{- range .Values.volumeMounts }}
             - {{ toYaml . | indent 14 | trim }}
-          {{- end }}
+          {{- end -}}
+      {{- if or (.Values.idracConfig) (.Values.volumes) }}
       volumes:
+      {{- end }}
+      {{- if or .Values.idracConfig }}
         - name: config
           secret:
             secretName: {{ include "idrac-exporter.fullname" . }}-config
+      {{- end }}
       {{- range .Values.volumes }}
         - {{ toYaml . | indent 10 | trim }}
       {{- end }}

--- a/charts/idrac-exporter/values.yaml
+++ b/charts/idrac-exporter/values.yaml
@@ -57,12 +57,17 @@ readinessProbe:
     port: http
 
 volumes: []
+# - name: config-templated
+#   emptyDir:
+#     sizeLimit: 16Mi
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
 volumeMounts: []
+# - mountPath: /app/config
+#   name: config-templated
 # - name: foo
 #   mountPath: "/etc/foo"
 #   readOnly: true
@@ -72,6 +77,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# If true idracConfig mounts as "idrac.yml.template" to be used with environment
+# variables in entrypoint.sh for container deployments.
+idracConfigIsTemplate: false
 
 idracConfig: |
   address: 0.0.0.0   # Running in a container, this makes sense
@@ -90,6 +99,15 @@ idracConfig: |
     storage: true
     memory: true
     network: true
+
+env: []
+# - name: IDRAC_USERNAME
+#   value: root
+# - name: IDRAC_PASSWORD
+#   valueFrom:
+#     secretKeyRef:
+#        name: my-external-idrac-secret
+#        key: idrac-password
 
 podAnnotations:
   prometheus.io/scrape: "false"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,10 @@
 
 config=/etc/prometheus/idrac.yml
 
-if [ ! -e "$config" ]; then
+if [[ ! -z "$IDRAC_USERNAME" ]] && [[ ! -z "$IDRAC_PASSWORD" ]]; then
+	envsubst <${config}.template > /app/config/idrac.yml
+	config=/app/config/idrac.yml
+elif [ ! -e "$config" ]; then
 	auth_file=/authconfig/$NODE_NAME
 
 	if [ ! -e "$auth_file" ]; then
@@ -11,9 +14,9 @@ if [ ! -e "$config" ]; then
 		# auth_file contents are in the format: user=password
 		export IDRAC_USERNAME=$(cut -f1  -d= $auth_file)
 		export IDRAC_PASSWORD=$(cut -f2- -d= $auth_file)
-		envsubst <${config}.template >${config}
+		envsubst <${config}.template > /app/config/idrac.yml
 	fi
 
 fi
 
-exec bin/idrac_exporter
+exec bin/idrac_exporter -config="$config"


### PR DESCRIPTION
https://github.com/mrlhansen/idrac_exporter/pull/30 added code without adding support to be compatible with the chart.
* Adds `env` to chart which is passed to the container, this allows the operator to mount a external secret as env to be used with the entrypoint script.
* Adds `idracConfigIsTemplate` as a new bool in chart. This will control if `idracConfig` secret key is `idrac.yml` or `idrac.yml.template`.
* Modify the entrypoint script to `envsubst` if IDRAC_USERNAME and IDRAC_PASSWORD is already exported in env, if not then continue with the logic added in PR 30.
* Generate config to /app/config in entrypoint to tmpfs volume. /etc/prometheus is mounted readOnly and we don't want to store the templated config with any persistence.

```sh
# Starting with IDRAC_USERNAME and IDRAC_PASSWORD defined:
➜  ~ docker run -it --rm -e IDRAC_USERNAME=test -e IDRAC_PASSWORD=test2 docker.io/library/idrac_exporter
2024-04-25T14:31:07.342 INFO  Build information: version=unknown revision=cc4a45ac19bf09cc21bf8f6f5e0dd86559458ba6
2024-04-25T14:31:07.342 INFO  Server listening on 0.0.0.0:9348

# Starting without env-vars defined just like today:
➜  ~ docker run -it --rm docker.io/library/idrac_exporter
/etc/prometheus/idrac.yml not found _and_ /authconfig/ not found.
2024-04-25T14:31:15.275 FATAL Error opening configuration file /etc/prometheus/idrac.yml: open /etc/prometheus/idrac.yml: no such file or directory
```

As mentioned above /etc/prometheus is mounted `readOnly` and so is root filesystem, so to support the templating generating a config I opted for a Kubernetes emptyDir to hold the generated runtime config and included commented snippets for that in the values file.

* Bumped appVersion to 1.2.2 so you'll have to tag a new release due to the edited entrypoint script.
* Bumped chart version for the changes made to the chart templating.

The idea with the added support is both to add the necessary customization (passing envvars) to the container for the existing entrypoint.
My/our usecase is to sync the default credentials from Hashicorp Vault to a secret in the kubernetes cluster, then reference that secret -> env var -> idrac_exporter. These changes makes that possible.