### PR TITLE
Add keep_firing_for to alerts

### DIFF
--- a/grafana/alerts.yaml
+++ b/grafana/alerts.yaml
@@ -4,6 +4,7 @@ groups:
       - alert: ServerNotHealthy
         expr: idrac_system_health{status!="OK"}
         for: 3m
+        keep_firing_for: 5m
         labels:
           severity: >
             {{- if $labels.status -}}
@@ -21,8 +22,9 @@ groups:
       - alert: ServerNotReporting
         expr: up{job=~".*idrac.*"} == 0
         for: 5m
+        keep_firing_for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           description: Server {{ $labels.instance }} is not reporting.
           summary: Hardware server failed to reply to monitoring.


### PR DESCRIPTION
To avoid alerts flapping due to timeous/network issues Decrese ServerNotReporting severity to warning (not always critical issue, due to various reasons such as networking, bad password , timeout etc) 

For critical signals, better to apply blackbox ping as well.