### PR TITLE
Build and push Docker image for arm64

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker login
         uses: docker/login-action@v3
         with:
@@ -36,6 +42,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ARG ARCH=
-FROM ${ARCH}golang:1.21-alpine3.18 as builder
+FROM ${ARCH}golang:1.21-alpine3.18 AS builder
 
 WORKDIR /app/src
 RUN apk add -U make git grep
 COPY . .
 RUN make build
 
-FROM ${ARCH}alpine:3.18 as container
+FROM ${ARCH}alpine:3.18 AS container
 
 WORKDIR /app
 COPY --from=builder /app/src/idrac_exporter /app/bin/


### PR DESCRIPTION
Hello, I wanted to use the Docker image on my Raspberry Pi and realized that the existing image was only available for amd64.

- I modified the Github workflow to build and push for both amd64 and arm64. Maybe you might want to add more platform, but this can be done later.
- I also fixed a warning in the Dockerfile, if preferred I can remove this commit.

As the pipeline is only run for tags, you can check the result on my repository (I'm pushing to Github Registry but Docker Hub also [supports multi-platform images](https://docs.docker.com/build/building/multi-platform/)).
(https://github.com/Vinrobot/idrac_exporter/actions/runs/10229723252/job/28303699185)