### PR TITLE
Change major version of module in go.mod to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mrlhansen/idrac_exporter
+module github.com/mrlhansen/idrac_exporter/v2
 
 go 1.21
 


### PR DESCRIPTION
This is necessary, otherwise versions 2.x.x will not install:

```
~ $ go install github.com/mrlhansen/idrac_exporter@v2.0.1        
go: github.com/mrlhansen/idrac_exporter@v2.0.1: github.com/mrlhansen/idrac_exporter@v2.0.1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/mrlhansen/idrac_exporter/v2")
~ $ go install github.com/mrlhansen/idrac_exporter/v2@v2.0.1
go: github.com/mrlhansen/idrac_exporter/v2@v2.0.1: github.com/mrlhansen/idrac_exporter@v2.0.1: invalid version: module contains a go.mod file, so module path must match major version ("github.com/mrlhansen/idrac_exporter/v2")
```