### PR TITLE
Add deployment annotations

### DIFF
--- a/charts/idrac-exporter/templates/deployment.yaml
+++ b/charts/idrac-exporter/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "idrac-exporter.fullname" . }}
   labels:
     {{- include "idrac-exporter.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/idrac-exporter/values.yaml
+++ b/charts/idrac-exporter/values.yaml
@@ -100,6 +100,8 @@ env: []
 #        name: my-external-idrac-secret
 #        key: idrac-password
 
+deploymentAnnotations: {}
+
 podAnnotations:
   prometheus.io/scrape: "false"
   prometheus.io/path: "/metrics"


### PR DESCRIPTION
This is useful for users who want to add annotations at the deployment level. e.g.:
```
    deploymentAnnotations:
      reloader.stakater.com/auto: "true"
```