### PR TITLE
Add ability to provide idracConfig from an existing secret

### DIFF
--- a/charts/idrac-exporter/templates/config.yaml
+++ b/charts/idrac-exporter/templates/config.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.idracConfig }}
+{{- if and (not .Values.existingSecret) .Values.idracConfig }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,4 +7,4 @@ metadata:
     {{- include "idrac-exporter.labels" . | nindent 4 }}
 stringData:
   idrac.yml: {{ tpl .Values.idracConfig . | quote }}
-{{ end }}
+{{- end }}

--- a/charts/idrac-exporter/templates/deployment.yaml
+++ b/charts/idrac-exporter/templates/deployment.yaml
@@ -58,10 +58,10 @@ spec:
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (.Values.idracConfig) (.Values.volumeMounts) }}
+          {{- if or (.Values.idracConfig) (.Values.existingSecret) (.Values.volumeMounts) }}
           volumeMounts:
           {{- end }}
-            {{- if .Values.idracConfig }}
+            {{- if or .Values.idracConfig .Values.existingSecret }}
             - mountPath: "/etc/prometheus"
               name: config
               readOnly: true
@@ -69,13 +69,13 @@ spec:
           {{- range .Values.volumeMounts }}
             - {{ toYaml . | indent 14 | trim }}
           {{- end -}}
-      {{- if or (.Values.idracConfig) (.Values.volumes) }}
+      {{- if or (.Values.idracConfig) (.Values.existingSecret) (.Values.volumes) }}
       volumes:
       {{- end }}
-      {{- if or .Values.idracConfig }}
+      {{- if or .Values.idracConfig .Values.existingSecret }}
         - name: config
           secret:
-            secretName: {{ include "idrac-exporter.fullname" . }}-config
+            secretName: {{ .Values.existingSecret | default (printf "%s-config" (include "idrac-exporter.fullname" .)) }}
       {{- end }}
       {{- range .Values.volumes }}
         - {{ toYaml . | indent 10 | trim }}

--- a/charts/idrac-exporter/values.yaml
+++ b/charts/idrac-exporter/values.yaml
@@ -80,6 +80,8 @@ affinity: {}
 
 extraArgs: []
 
+existingSecret: ""
+
 idracConfig: |
   address: 0.0.0.0
   port: 9348


### PR DESCRIPTION
This is useful for users who want to deploy the helm chart securely without exposing secrets by adding them to the values override.