### PR TITLE
feat: add master branch trigger for Docker image publish

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -2,6 +2,7 @@ name: Publish Docker Images
 
 on:
   push:
+    branches: ['master']
     tags: ['v*']
 
 permissions:


### PR DESCRIPTION
Right now there is no way to get a image with some fix or feature which is just committed in master but release not created as in current `image` is not getting created and only get created when a new tag or release get created.

Creating a new tag and release for each commit/feature is not feasible, so adding logic to create image from master.