### PR TITLE
feat: add -version flag to show the build information and exit gracefully

### DIFF
--- a/cmd/idrac_exporter/main.go
+++ b/cmd/idrac_exporter/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"runtime"
 	"strings"
 
 	"github.com/mrlhansen/idrac_exporter/internal/config"
@@ -14,18 +16,29 @@ import (
 
 func main() {
 	var (
-		verbose bool
-		debug   bool
-		file    string
-		watch   bool
-		err     error
+		verbose     bool
+		debug       bool
+		file        string
+		watch       bool
+		versionOnly bool
+		err         error
 	)
 
 	flag.BoolVar(&verbose, "verbose", false, "Enable more verbose logging")
 	flag.BoolVar(&debug, "debug", false, "Dump JSON response from Redfish requests (only for debugging purpose)")
 	flag.StringVar(&file, "config", "/etc/prometheus/idrac.yml", "Path to the configuration file")
 	flag.BoolVar(&watch, "config-watch", false, "Watch the configuration file for changes and enable automatic reloading")
+	flag.BoolVar(&versionOnly, "version", false, "Show the version and exit gracefully")
 	flag.Parse()
+
+	if versionOnly {
+		fmt.Println(fmt.Sprintf("version: %s", version.Version))
+		fmt.Println(fmt.Sprintf("revision: %s", version.Revision))
+		fmt.Println(fmt.Sprintf("goversion: %s", runtime.Version()))
+		fmt.Println(fmt.Sprintf("os: %s", runtime.GOOS))
+		fmt.Println(fmt.Sprintf("architecture: %s", runtime.GOARCH))
+		os.Exit(0)
+	}
 
 	log.Info("Build information: version=%s revision=%s", version.Version, version.Revision)
 	LoadConfig(file, watch)


### PR DESCRIPTION
Hey,
i am deploying this tool via ansible and want to have a simple shortcut to only fetch the current version. I need this information, as i want ansible to decide, whether it should download the binary again and replace it, or just simply skip these steps.

May you can have a look on this @mrlhansen? Its just a simple code change, but very important for me.