### PR TITLE
Clean up Dockerfile and entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-ARG ARCH=
-FROM ${ARCH}golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine3.20 AS builder
 
 WORKDIR /app/src
 RUN apk add -U make git grep
 COPY . .
 RUN make build
 
-FROM ${ARCH}alpine:3.20 AS container
+FROM alpine:3.20 AS container
 
 WORKDIR /app
 COPY --from=builder /app/src/idrac_exporter /app/bin/
-RUN apk add -U bash
+RUN apk --no-cache upgrade
 COPY default-config.yml /etc/prometheus/idrac.yml
 COPY entrypoint.sh /app
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-auth_file="/authconfig/$NODE_NAME"
-if [ -f "$auth_file" ]; then
-	export CONFIG_DEFAULT_USERNAME=$(cut -f1  -d= $auth_file)
-	export CONFIG_DEFAULT_PASSWORD=$(cut -f2- -d= $auth_file)
+auth_file="/authconfig/${NODE_NAME}"
+if [ -f "${auth_file}" ]; then
+	CONFIG_DEFAULT_USERNAME="$(cut -f1 -d= "${auth_file}")"
+	CONFIG_DEFAULT_PASSWORD="$(cut -f2- -d= "${auth_file}")"
+	export CONFIG_DEFAULT_USERNAME CONFIG_DEFAULT_PASSWORD
 fi
 
 exec bin/idrac_exporter "$@"


### PR DESCRIPTION
Hi @mrlhansen,
I have just cleaned up the Dockerfile as well as the entrypoint.sh.

I have removed the unused `ARCH` argument, added a line to update packages inside of Alpine and removed bash. I have tested this locally and the move to `sh` over bash should not cause any issues. I also generally cleaned up the entrypoint file in order to better match shell-scripting best practices.