### PR TITLE
Updated redfish http transport settings

### DIFF
--- a/internal/collector/redfish.go
+++ b/internal/collector/redfish.go
@@ -48,8 +48,13 @@ func NewRedfish(h *config.HostConfig) *Redfish {
 		},
 		http: &http.Client{
 			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				Proxy:                 http.ProxyFromEnvironment,
+				TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+				MaxIdleConnsPerHost:   10,                                                 // Allow more concurrent requests per host
+				MaxConnsPerHost:       20,                                                 // Limit total connections per host
+				IdleConnTimeout:       30 * time.Second,                                   // Remove stale connections after 30s
+				ResponseHeaderTimeout: time.Duration(config.Config.Timeout) * time.Second, // Timeout waiting for response headers
+				ExpectContinueTimeout: 1 * time.Second,                                    // Timeout for 100-continue responses
 			},
 			Timeout: time.Duration(config.Config.Timeout) * time.Second,
 		},


### PR DESCRIPTION
While using the exporter, we ran into connections suddenly going stale and keep timing out while waiting for a header. The issue was only fixed by restarting the container.

Key improvements:

1. MaxIdleConnsPerHost: 10 - Allows more concurrent metric collection (up from default of 2)
2. MaxConnsPerHost: 20 - Limits total connections to prevent resource exhaustion
3. IdleConnTimeout: 30 * time.Second - Most critical fix - Automatically removes stale connections from the pool after 30 seconds of inactivity
4. ResponseHeaderTimeout - Uses the configured timeout specifically for waiting for response headers, preventing hangs
5. ExpectContinueTimeout: 1 * time.Second - Handles 100-continue responses efficiently