### PR TITLE
fix: add missing Network and Processors paths for iLO 4

### DIFF
--- a/internal/collector/client.go
+++ b/internal/collector/client.go
@@ -198,6 +198,8 @@ func (client *Client) findAllEndpoints() bool {
 		if strings.Contains(root.Name, "HP RESTful") {
 			client.path.Memory = "/redfish/v1/Systems/1/Memory/"
 			client.path.Storage = "/redfish/v1/Systems/1/SmartStorage/ArrayControllers/"
+			client.path.Network = "/redfish/v1/Systems/1/NetworkAdapters/"
+			client.path.Processors = "/redfish/v1/Systems/1/Processors/"
 			client.path.Event = ""
 			client.version = 4
 		}
@@ -369,6 +371,13 @@ func (client *Client) RefreshProcessors(mc *Collector, ch chan<- prometheus.Metr
 			continue
 		}
 
+		// iLO 4
+		if (client.vendor == HPE) && (client.version == 4) {
+			if resp.Status.State == "" && resp.Status.Health != "" {
+				resp.Status.State = StateEnabled
+			}
+		}
+
 		if resp.Status.State != StateEnabled {
 			continue
 		}
@@ -397,6 +406,22 @@ func (client *Client) RefreshNetwork(mc *Collector, ch chan<- prometheus.Metric)
 		ok = client.redfish.Get(c, &ni)
 		if !ok {
 			return false
+		}
+
+		// iLO 4
+		if (client.vendor == HPE) && (client.version == 4) {
+			if ni.Model == "" {
+				ni.Model = ni.Name
+			}
+			mc.NewNetworkAdapterInfo(ch, &ni)
+			for n, p := range ni.PhysicalPorts {
+				port := NetworkPort{
+					Id:                   strconv.Itoa(n),
+					CurrentLinkSpeedMbps: p.SpeedMbps,
+				}
+				mc.NewNetworkPortCurrentSpeed(ch, ni.Id, &port)
+			}
+			continue
 		}
 
 		mc.NewNetworkAdapterInfo(ch, &ni)

--- a/internal/collector/model.go
+++ b/internal/collector/model.go
@@ -462,6 +462,13 @@ type NetworkAdapter struct {
 	Controllers  []struct {
 		FirmwarePackageVersion string `json:"FirmwarePackageVersion"`
 	} `json:"Controllers"`
+	PhysicalPorts []PhysicalPort `json:"PhysicalPorts"` // iLO 4
+}
+
+type PhysicalPort struct {
+	MacAddress string  `json:"MacAddress"`
+	SpeedMbps  float64 `json:"SpeedMbps"`
+	FullDuplex bool    `json:"FullDuplex"`
 }
 
 func (n *NetworkAdapter) GetPorts() string {


### PR DESCRIPTION
Fixes #181

## Summary

- Add Network and Processors path assignments to the iLO 4 fixup block in `findAllEndpoints()`
- Fix Processors collection: set `Status.State = "Enabled"` when iLO 4 only returns `Status.Health`
- Fix Network collection: handle iLO 4's inline `PhysicalPorts` and map `Name` to `Model` for adapter info

## Example output

Processors (previously not collected):
```text
idrac_cpu_info{arch="x86-64",id="1",manufacturer="Intel(R) Corporation",model="Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",socket="Proc 1"} 1
idrac_cpu_info{arch="x86-64",id="2",manufacturer="Intel(R) Corporation",model="Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",socket="Proc 2"} 1
idrac_cpu_total_cores{id="1"} 8
idrac_cpu_total_threads{id="1"} 16
```

Network adapters (previously 1 adapter with empty fields + scrape errors):
```text
idrac_network_adapter_info{id="1",manufacturer="",model="HPE Ethernet 1Gb 4-port 331i Adapter - NIC",serial=""} 1
idrac_network_adapter_info{id="2",manufacturer="",model="HP Ethernet 10Gb 2-port 560SFP+ Adapter",serial="MYI52505PR"} 1
idrac_network_adapter_info{id="3",manufacturer="",model="HP Ethernet 10Gb 2-port 560SFP+ Adapter",serial="MYI6150GJY"} 1
```

## Test plan

- [x] Tested against 3x HP DL380 Gen9 with iLO 4 v2.82
- [x] Verified no scrape errors
- [x] Verified no regressions to existing metrics (sensors, power, storage, memory, system)