### PR TITLE
enhance: strip trademark symbols from CPU manufacturer and model labels

### DIFF
--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -9,6 +9,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var trademarkReplacer = strings.NewReplacer("(R)", "", "(TM)", "", "(C)", "")
+
+func cleanTrademarks(s string) string {
+	return strings.Join(strings.Fields(trademarkReplacer.Replace(s)), " ")
+}
+
 func health2value(health string) int {
 	switch health {
 	case "":
@@ -103,7 +109,7 @@ func (mc *Collector) NewSystemCpuCount(ch chan<- prometheus.Metric, m *SystemRes
 		mc.SystemCpuCount,
 		prometheus.GaugeValue,
 		float64(m.ProcessorSummary.Count),
-		strings.TrimSpace(m.ProcessorSummary.Model),
+		cleanTrademarks(m.ProcessorSummary.Model),
 	)
 }
 
@@ -661,8 +667,8 @@ func (mc *Collector) NewCpuInfo(ch chan<- prometheus.Metric, m *Processor) {
 		1.0,
 		m.Id,
 		m.Socket,
-		strings.TrimSpace(m.Manufacturer),
-		strings.TrimSpace(m.Model),
+		cleanTrademarks(m.Manufacturer),
+		cleanTrademarks(m.Model),
 		arch.String(),
 	)
 }


### PR DESCRIPTION
Fixes #183

## Summary

Strip `(R)`, `(TM)`, and `(C)` from CPU-related metric labels and collapse extra whitespace.

Before:
```text
idrac_cpu_info{manufacturer="Intel(R) Corporation",model="Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz",...} 1
idrac_system_cpu_count{model="Intel(R) Xeon(R) CPU E5-2630 v3 @ 2.40GHz"} 2
```

After:
```text
idrac_cpu_info{manufacturer="Intel Corporation",model="Intel Xeon CPU E5-2630 v3 @ 2.40GHz",...} 1
idrac_system_cpu_count{model="Intel Xeon CPU E5-2630 v3 @ 2.40GHz"} 2
```

## Test plan

- [x] Tested against 3x HP DL380 Gen9 with iLO 4 v2.82
- [x] Verified trademark symbols removed from all CPU labels
- [x] Verified no regressions to other metrics