### PR TITLE
feat: add BMC info metric with firmware version

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,20 +215,20 @@ idrac_network_port_current_speed_mbps{adapter_id,id}
 idrac_network_port_link_up{adapter_id,id,status}
 ```
 
+### Manager
+These metrics contain information about the baseboard management controller (BMC). Currently only exported for HPE systems.
+
+```text
+idrac_manager_info{id,firmware,model,type}
+idrac_manager_health{id,status}
+```
+
 ### Extra
 These metrics do not belong anywhere else and they might be OEM specific. At the moment only some Dell specific metrics are exported.
 
 ```text
 idrac_dell_battery_rollup_health{status}
 idrac_dell_estimated_system_airflow_cfm
-idrac_dell_manager_info{model,type,version}
-```
-
-### BMC
-These metrics contain information about the baseboard management controller (BMC). Currently only exported for HPE systems.
-
-```text
-idrac_bmc_info{firmware,model,type}
 ```
 
 ### Exporter

--- a/internal/collector/client.go
+++ b/internal/collector/client.go
@@ -141,8 +141,8 @@ func (client *Client) findAllEndpoints() bool {
 		client.vendor = DELL
 	}
 
-	// Path for manager (BMC firmware info)
-	if client.vendor == HPE {
+	// Path for manager
+	if config.Config.Collect.Manager {
 		ok = client.redfish.Get(root.Managers.OdataId, &group)
 		if ok && len(group.Members) > 0 {
 			client.path.Manager = group.Members[0].OdataId
@@ -183,16 +183,11 @@ func (client *Client) findAllEndpoints() bool {
 		}
 	}
 
-	// Dell OEM
+	// Extra
 	if config.Config.Collect.Extra {
 		if client.vendor == DELL {
 			if client.redfish.Exists(DellSystemPath) {
 				client.path.Extra = append(client.path.Extra, DellSystemPath)
-			}
-			if client.redfish.Exists(DellAttributesPath) {
-				client.path.Extra = append(client.path.Extra, DellAttributesPath)
-			} else if client.redfish.Exists(DellManagerPath) {
-				client.path.Extra = append(client.path.Extra, DellManagerPath)
 			}
 		}
 	}
@@ -357,12 +352,18 @@ func (client *Client) RefreshSystem(mc *Collector, ch chan<- prometheus.Metric) 
 	mc.NewSystemBiosInfo(ch, &resp)
 	mc.NewSystemMachineInfo(ch, &resp)
 
-	if client.path.Manager != "" {
-		mgr := ManagerResponse{}
-		if client.redfish.Get(client.path.Manager, &mgr) {
-			mc.NewBmcInfo(ch, &mgr)
-		}
+	return true
+}
+
+func (client *Client) RefreshManager(mc *Collector, ch chan<- prometheus.Metric) bool {
+	mgr := ManagerResponse{}
+	ok := client.redfish.Get(client.path.Manager, &mgr)
+	if !ok {
+		return false
 	}
+
+	mc.NewManagerInfo(ch, &mgr)
+	mc.NewManagerHealth(ch, &mgr)
 
 	return true
 }
@@ -822,26 +823,6 @@ func (client *Client) RefreshDell(mc *Collector, ch chan<- prometheus.Metric) bo
 		if ok {
 			mc.NewDellBatteryRollupHealth(ch, &resp)
 			mc.NewDellEstimatedSystemAirflowCFM(ch, &resp)
-		} else {
-			result = false
-		}
-	}
-
-	if slices.Contains(client.path.Extra, DellAttributesPath) {
-		resp := DellAttributes{}
-		ok := client.redfish.Get(DellAttributesPath, &resp)
-		if ok {
-			mc.NewDellManagerInfo(ch, resp.Attributes.InfoType, resp.Attributes.InfoVersion, resp.Attributes.InfoHWModel)
-		} else {
-			result = false
-		}
-	}
-
-	if slices.Contains(client.path.Extra, DellManagerPath) {
-		resp := DellManager{}
-		ok := client.redfish.Get(DellManagerPath, &resp)
-		if ok {
-			mc.NewDellManagerInfo(ch, resp.Model, resp.FirmwareVersion, resp.ManagerType)
 		} else {
 			result = false
 		}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -103,13 +103,13 @@ type Collector struct {
 	CpuTotalThreads *prometheus.Desc
 
 	// BMC
-	BmcInfo *prometheus.Desc
+	ManagerInfo   *prometheus.Desc
+	ManagerHealth *prometheus.Desc
 
 	// Dell OEM
 	DellBatteryRollupHealth       *prometheus.Desc
 	DellEstimatedSystemAirflowCFM *prometheus.Desc
 	DellControllerBatteryHealth   *prometheus.Desc
-	DellManagerInfo               *prometheus.Desc
 }
 
 func NewCollector() *Collector {
@@ -405,10 +405,15 @@ func NewCollector() *Collector {
 			"Total number of CPU threads",
 			[]string{"id"}, nil,
 		),
-		BmcInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "bmc", "info"),
-			"Information about the BMC",
-			[]string{"type", "model", "firmware"}, nil,
+		ManagerInfo: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "manager", "info"),
+			"Information about the manager",
+			[]string{"id", "type", "model", "firmware"}, nil,
+		),
+		ManagerHealth: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "manager", "health"),
+			"Health status of the manager",
+			[]string{"id", "status"}, nil,
 		),
 		DellBatteryRollupHealth: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "dell", "battery_rollup_health"),
@@ -424,11 +429,6 @@ func NewCollector() *Collector {
 			prometheus.BuildFQName(prefix, "dell", "controller_battery_health"),
 			"Health status of storage controller battery",
 			[]string{"id", "storage_id", "name", "status"}, nil,
-		),
-		DellManagerInfo: prometheus.NewDesc(
-			prometheus.BuildFQName(prefix, "dell", "manager_info"),
-			"Information about iDRAC manager",
-			[]string{"type", "version", "model"}, nil,
 		),
 	}
 
@@ -498,7 +498,8 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.CpuCurrentSpeed
 	ch <- collector.CpuTotalCores
 	ch <- collector.CpuTotalThreads
-	ch <- collector.BmcInfo
+	ch <- collector.ManagerInfo
+	ch <- collector.ManagerHealth
 	ch <- collector.DellBatteryRollupHealth
 	ch <- collector.DellEstimatedSystemAirflowCFM
 	ch <- collector.DellControllerBatteryHealth
@@ -591,6 +592,17 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 		wg.Add(1)
 		go func() {
 			ok := collector.client.RefreshProcessors(collector, ch)
+			if !ok {
+				collector.errors.Add(1)
+			}
+			wg.Done()
+		}()
+	}
+
+	if collect.Manager {
+		wg.Add(1)
+		go func() {
+			ok := collector.client.RefreshManager(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -795,24 +795,28 @@ func (mc *Collector) NewDellControllerBatteryHealth(ch chan<- prometheus.Metric,
 	)
 }
 
-func (mc *Collector) NewBmcInfo(ch chan<- prometheus.Metric, m *ManagerResponse) {
+func (mc *Collector) NewManagerInfo(ch chan<- prometheus.Metric, m *ManagerResponse) {
 	ch <- prometheus.MustNewConstMetric(
-		mc.BmcInfo,
+		mc.ManagerInfo,
 		prometheus.UntypedValue,
 		1.0,
+		m.Id,
 		m.ManagerType,
 		m.Model,
 		m.FirmwareVersion,
 	)
 }
 
-func (mc *Collector) NewDellManagerInfo(ch chan<- prometheus.Metric, mtype, version, model string) {
+func (mc *Collector) NewManagerHealth(ch chan<- prometheus.Metric, m *ManagerResponse) {
+	value := health2value(m.Status.Health)
+	if value < 0 {
+		return
+	}
 	ch <- prometheus.MustNewConstMetric(
-		mc.DellManagerInfo,
+		mc.ManagerHealth,
 		prometheus.GaugeValue,
-		1.0,
-		mtype,
-		version,
-		model,
+		float64(value),
+		m.Id,
+		m.Status.Health,
 	)
 }

--- a/internal/collector/model.go
+++ b/internal/collector/model.go
@@ -768,11 +768,22 @@ type EventLogResponse struct {
 	} `json:"Members"`
 }
 
+type ManagerResponse struct {
+	Id                    string `json:"Id"`
+	Name                  string `json:"Name"`
+	Description           string `json:"Description"`
+	ManagerType           string `json:"ManagerType"`
+	Model                 string `json:"Model"`
+	FirmwareVersion       string `json:"FirmwareVersion"`
+	ServiceIdentification string `json:"ServiceIdentification"`
+	TimeZoneName          string `json:"TimeZoneName"`
+	Status                Status `json:"Status"`
+}
+
 // Dell OEM
 const (
 	DellSystemPath     string = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSystem/System.Embedded.1"
 	DellAttributesPath string = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/iDRAC.Embedded.1"
-	DellManagerPath    string = "/redfish/v1/Managers/iDRAC.Embedded.1"
 )
 
 type DellSystem struct {
@@ -812,23 +823,4 @@ type DellAttributes struct {
 		InfoHWModel   string `json:"Info.1.HWModel"`
 		InfoVersion   string `json:"Info.1.Version"`
 	} `json:"Attributes"`
-}
-
-type ManagerResponse struct {
-	Id              string `json:"Id"`
-	Name            string `json:"Name"`
-	ManagerType     string `json:"ManagerType"`
-	Model           string `json:"Model"`
-	FirmwareVersion string `json:"FirmwareVersion"`
-	Status          Status `json:"Status"`
-}
-
-type DellManager struct {
-	Id              string `json:"Id"`
-	Name            string `json:"Name"`
-	Description     string `json:"Description"`
-	ManagerType     string `json:"ManagerType"`
-	Model           string `json:"Model"`
-	FirmwareVersion string `json:"FirmwareVersion"`
-	Status          Status `json:"Status"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,7 @@ func (c *RootConfig) Validate() error {
 		c.Collect.Memory = true
 		c.Collect.Network = true
 		c.Collect.Processors = true
+		c.Collect.Manager = true
 		c.Collect.Extra = true
 	}
 

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -76,6 +76,7 @@ func (c *RootConfig) FromEnvironment() {
 	getEnvBool("CONFIG_METRICS_MEMORY", &c.Collect.Memory)
 	getEnvBool("CONFIG_METRICS_NETWORK", &c.Collect.Network)
 	getEnvBool("CONFIG_METRICS_PROCESSORS", &c.Collect.Processors)
+	getEnvBool("CONFIG_METRICS_MANAGER", &c.Collect.Manager)
 	getEnvBool("CONFIG_METRICS_EXTRA", &c.Collect.Extra)
 
 	def, ok := c.Hosts["default"]

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -20,6 +20,7 @@ type CollectConfig struct {
 	Memory     bool `yaml:"memory"`
 	Network    bool `yaml:"network"`
 	Processors bool `yaml:"processors"`
+	Manager    bool `yaml:"manager"`
 	Extra      bool `yaml:"extra"`
 }
 

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -99,6 +99,7 @@ metrics:
   storage: false     # CONFIG_METRICS_STORAGE=false
   memory: false      # CONFIG_METRICS_MEMORY=false
   network: false     # CONFIG_METRICS_NETWORK=false
+  manager: false     # CONFIG_METRICS_MANAGER=false
   extra: false       # CONFIG_METRICS_EXTRA=false
 
 # The events section is used for filtering events when the "events" metrics group


### PR DESCRIPTION
Fixes #185

## Summary

Add a new `idrac_bmc_info` metric that exposes BMC type, model, and firmware version from the standard Redfish Managers endpoint. Currently enabled for HPE only.

Example output:
```text
idrac_bmc_info{firmware="iLO 4 v2.82",model="",type="BMC"} 1
```

## Changes

- Add `ManagerResponse` model with standard Redfish Manager fields
- Discover first manager path from `/redfish/v1/Managers/` during endpoint discovery (HPE only)
- Emit `idrac_bmc_info` metric during system collection
- Document new metric in README

## Test plan

- [x] Tested against 3x HP DL380 Gen9 with iLO 4 v2.82
- [x] Verified firmware version correctly reported
- [x] Verified no scrape errors or regressions