### PR TITLE
Add configurable concurrency limit for metric collection

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -507,6 +507,7 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 
 func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	var wg sync.WaitGroup
+	sem := make(chan struct{}, int(config.Config.Concurrency))
 
 	collector.client.redfish.RefreshSession()
 	collect := &config.Config.Collect
@@ -514,110 +515,130 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	if collect.System {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshSystem(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Sensors {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshSensors(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Power {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshPower(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Network {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshNetwork(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Events {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshEventLog(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Storage {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshStorage(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Memory {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshMemory(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Processors {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshProcessors(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Manager {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshManager(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 
 	if collect.Extra {
 		wg.Add(1)
 		go func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			defer wg.Done()
 			ok := collector.client.RefreshDell(collector, ch)
 			if !ok {
 				collector.errors.Add(1)
 			}
-			wg.Done()
 		}()
 	}
 

--- a/internal/collector/redfish.go
+++ b/internal/collector/redfish.go
@@ -50,8 +50,8 @@ func NewRedfish(host string, auth *config.AuthConfig) *Redfish {
 			Transport: &http.Transport{
 				Proxy:                 http.ProxyFromEnvironment,
 				TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-				MaxIdleConnsPerHost:   10,                                                 // Allow more concurrent requests per host
-				MaxConnsPerHost:       20,                                                 // Limit total connections per host
+				MaxIdleConnsPerHost:   int(config.Config.Concurrency),                         // Match concurrency setting
+				MaxConnsPerHost:       int(config.Config.Concurrency) + 1,                    // +1 for session management
 				IdleConnTimeout:       30 * time.Second,                                   // Remove stale connections after 30s
 				ResponseHeaderTimeout: time.Duration(config.Config.Timeout) * time.Second, // Timeout waiting for response headers
 				ExpectContinueTimeout: 1 * time.Second,                                    // Timeout for 100-continue responses

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,10 @@ func (c *RootConfig) Validate() error {
 		c.MetricsPrefix = "idrac"
 	}
 
+	if c.Concurrency == 0 {
+		c.Concurrency = 10
+	}
+
 	// hosts
 	for k, v := range c.Hosts {
 		err := v.Validate()

--- a/internal/config/model.go
+++ b/internal/config/model.go
@@ -48,6 +48,7 @@ type RootConfig struct {
 	Event         EventConfig            `yaml:"events"`
 	TLS           TLSConfig              `yaml:"tls"`
 	Timeout       uint                   `yaml:"timeout"`
+	Concurrency   uint                   `yaml:"concurrency"`
 	Hosts         map[string]*AuthConfig `yaml:"hosts"`
 	Auths         map[string]*AuthConfig `yaml:"auths"`
 }


### PR DESCRIPTION
Add a 'concurrency' config option that limits how many metric collection goroutines run simultaneously per target. This prevents overwhelming BMCs with too many parallel Redfish requests, which causes 504 Gateway Timeout errors on slower hardware.

The HTTP transport MaxConnsPerHost is tied to the concurrency value (+1 for session management headroom). Default is 10 (preserves existing behavior). Also defer wg.Done() in all collection goroutines to prevent hangs on panic.

Config example:
``` YAML
address: 127.0.0.1
port: 9348
timeout: 60
concurrency: 4
```