### PR TITLE
Emit voltage sensors from the legacy Power resource (fixes #195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,13 @@ idrac_system_machine_info{manufacturer,model,serial,sku}
 ```
 
 ### Sensors
-These metrics include temperature and FAN health and speeds.
+These metrics include temperature, FAN health and speeds, and voltage sensor readings (such as board rails and the CMOS battery, where the BMC reports them via the legacy Power resource).
 
 ```text
 idrac_sensors_temperature{id,name,units}
 idrac_sensors_fan_health{id,name,status}
 idrac_sensors_fan_speed{id,name,units}
+idrac_sensors_voltage{id,name,units}
 ```
 
 ### Power

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ idrac_system_machine_info{manufacturer,model,serial,sku}
 ```
 
 ### Sensors
-These metrics include temperature, FAN health and speeds, and voltage sensor readings (such as board rails and the CMOS battery, where the BMC reports them via the legacy Power resource).
+These metrics include temperature, FAN health and speeds, and voltage sensor readings (such as board rails and the CMOS battery, where the BMC reports them via the legacy Power resource). The voltage metric is part of the sensors metrics group; when the power group is also enabled, the readings are collected together with the power metrics at no additional cost.
 
 ```text
 idrac_sensors_temperature{id,name,units}

--- a/internal/collector/client.go
+++ b/internal/collector/client.go
@@ -649,6 +649,21 @@ func (client *Client) RefreshPowerOld(mc *Collector, ch chan<- prometheus.Metric
 		mc.NewPowerControlInterval(ch, pm.IntervalInMinutes, id, pc.Name)
 	}
 
+	// Voltage sensors. The Voltages array is part of the Power response already
+	// fetched above, so emitting these costs no additional Redfish requests. On
+	// many BMCs (e.g. Lenovo XCC) it includes the board rails and the CMOS/RTC
+	// battery. Entries without a usable reading are skipped.
+	for i, v := range resp.Voltages {
+		if v.Name == "" {
+			continue
+		}
+		value, ok := asFloat64(v.ReadingVolts)
+		if !ok {
+			continue
+		}
+		mc.NewSensorsVoltage(ch, value, strconv.Itoa(i), v.Name, "volts")
+	}
+
 	return true
 }
 

--- a/internal/collector/client.go
+++ b/internal/collector/client.go
@@ -649,10 +649,39 @@ func (client *Client) RefreshPowerOld(mc *Collector, ch chan<- prometheus.Metric
 		mc.NewPowerControlInterval(ch, pm.IntervalInMinutes, id, pc.Name)
 	}
 
-	// Voltage sensors. The Voltages array is part of the Power response already
-	// fetched above, so emitting these costs no additional Redfish requests. On
-	// many BMCs (e.g. Lenovo XCC) it includes the board rails and the CMOS/RTC
-	// battery. Entries without a usable reading are skipped.
+	// Voltage sensors belong to the sensors metrics group, but the data lives
+	// in the Power response fetched above, so when both groups are enabled they
+	// are emitted here at no additional cost.
+	if config.Config.Collect.Sensors {
+		client.emitVoltages(mc, ch, &resp)
+	}
+
+	return true
+}
+
+// RefreshVoltages emits the voltage sensors from the legacy Power resource. It
+// is used when the sensors metrics group is enabled but the power group is not;
+// when both groups are enabled the voltages are instead emitted during
+// RefreshPowerOld, from the response that is fetched there anyway.
+func (client *Client) RefreshVoltages(mc *Collector, ch chan<- prometheus.Metric) bool {
+	if client.path.Power == "" {
+		return true
+	}
+
+	resp := PowerResponse{}
+	ok := client.redfish.Get(client.path.Power, &resp)
+	if !ok {
+		return false
+	}
+
+	client.emitVoltages(mc, ch, &resp)
+	return true
+}
+
+// emitVoltages emits the entries of the Voltages array found in the legacy
+// Power resource. On many BMCs (e.g. Lenovo XCC) this includes the board rails
+// and the CMOS/RTC battery. Entries without a usable reading are skipped.
+func (client *Client) emitVoltages(mc *Collector, ch chan<- prometheus.Metric, resp *PowerResponse) {
 	for i, v := range resp.Voltages {
 		if v.Name == "" {
 			continue
@@ -663,8 +692,6 @@ func (client *Client) RefreshPowerOld(mc *Collector, ch chan<- prometheus.Metric
 		}
 		mc.NewSensorsVoltage(ch, value, strconv.Itoa(i), v.Name, "volts")
 	}
-
-	return true
 }
 
 func (client *Client) RefreshPower(mc *Collector, ch chan<- prometheus.Metric) bool {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -43,6 +43,7 @@ type Collector struct {
 	SensorsTemperature *prometheus.Desc
 	SensorsFanHealth   *prometheus.Desc
 	SensorsFanSpeed    *prometheus.Desc
+	SensorsVoltage     *prometheus.Desc
 
 	// Power supply
 	PowerSupplyHealth            *prometheus.Desc
@@ -193,6 +194,11 @@ func NewCollector() *Collector {
 		SensorsFanSpeed: prometheus.NewDesc(
 			prometheus.BuildFQName(prefix, "sensors", "fan_speed"),
 			"Sensors reporting fan speed measurements",
+			[]string{"id", "name", "units"}, nil,
+		),
+		SensorsVoltage: prometheus.NewDesc(
+			prometheus.BuildFQName(prefix, "sensors", "voltage"),
+			"Sensors reporting voltage measurements",
 			[]string{"id", "name", "units"}, nil,
 		),
 		PowerSupplyHealth: prometheus.NewDesc(
@@ -504,6 +510,7 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- collector.SensorsTemperature
 	ch <- collector.SensorsFanHealth
 	ch <- collector.SensorsFanSpeed
+	ch <- collector.SensorsVoltage
 	ch <- collector.PowerSupplyHealth
 	ch <- collector.PowerSupplyOutputWatts
 	ch <- collector.PowerSupplyInputWatts

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -592,6 +592,15 @@ func (collector *Collector) CollectServer(ch chan<- prometheus.Metric) {
 			if !ok {
 				collector.errors.Add(1)
 			}
+			// Voltage sensors live in the legacy Power resource. When the power
+			// group is enabled they are emitted as part of that collection (at
+			// no extra cost), otherwise they are fetched here.
+			if !collect.Power {
+				ok = collector.client.RefreshVoltages(collector, ch)
+				if !ok {
+					collector.errors.Add(1)
+				}
+			}
 			wg.Done()
 		}()
 	}

--- a/internal/collector/metrics.go
+++ b/internal/collector/metrics.go
@@ -172,6 +172,17 @@ func (mc *Collector) NewSensorsFanSpeed(ch chan<- prometheus.Metric, speed float
 	)
 }
 
+func (mc *Collector) NewSensorsVoltage(ch chan<- prometheus.Metric, voltage float64, id, name, units string) {
+	ch <- prometheus.MustNewConstMetric(
+		mc.SensorsVoltage,
+		prometheus.GaugeValue,
+		voltage,
+		id,
+		name,
+		units,
+	)
+}
+
 func (mc *Collector) NewPowerSupplyHealth(ch chan<- prometheus.Metric, health, id string) {
 	value := health2value(health)
 	if value < 0 {

--- a/internal/collector/unmarshal.go
+++ b/internal/collector/unmarshal.go
@@ -3,6 +3,8 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // When unmarshalling JSON, the "xstring" type can be one of the following
@@ -56,4 +58,20 @@ func (w *xstring) String() string {
 
 func asPtr[T any](v T) *T {
 	return &v
+}
+
+// asFloat64 coerces a value decoded into an "any" field (such as ReadingVolts,
+// which some BMCs serialize as a JSON string) into a float64.
+func asFloat64(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(x), 64)
+		if err != nil {
+			return 0, false
+		}
+		return f, true
+	}
+	return 0, false
 }


### PR DESCRIPTION
Follow-up to #195 with the zero-cost approach discussed there: the **Voltages[]** array in the legacy **/redfish/v1/Chassis/{id}/Power** resource is already decoded by **RefreshPowerOld** on every scrape — this PR just emits it. No additional Redfish requests, no walk of the modern **Sensors** collection (220 one-GET-per-sensor members on our XCC chassis, per the cost concern raised in the issue).

New metric, emitted under the existing **power** collection group since the data lives in the Power resource:

`textidrac_sensors_voltage{id,name,units}   # gauge, units="volts"`

Sample from a Lenovo XCC host (SR630 V2, the array has 4 entries):

```
textidrac_sensors_voltage{id="0",name="SysBrd 12V",units="volts"} 12.15
idrac_sensors_voltage{id="1",name="SysBrd 5V",units="volts"} 4.94
idrac_sensors_voltage{id="2",name="SysBrd 3.3V",units="volts"} 3.29
idrac_sensors_voltage{id="3",name="CMOS Battery",units="volts"} 3.07
```

And the motivating case — a host with a failing RTC coin cell (Lenovo event **FQXSPPW0035M**, which drives **idrac_system_health** to Critical with no component metric today):

`textidrac_sensors_voltage{id="3",name="CMOS Battery",units="volts"} 0.27`

against the documented **LowerThresholdCritical** of 2.25 V — so **idrac_sensors_voltage{name="CMOS Battery"}** < 2.25 makes this directly alertable.

Design notes:

- Reading only, no health series. On XCC the **Voltages[]** entries carry **Status.State** but no **Status.Health**, so a health metric would be empty or misleading; alerting on the reading against a threshold is robust across vendors. (Threshold values could be emitted as companion gauges later if there's interest — kept out of scope here.)
 
- **asFloat64** coercion because **ReadingVolts** is declared **any** in the model (some BMCs serialize numbers as strings). Entries with a missing/unparseable reading are skipped, matching the legacy thermal loop's convention.
 
- **id** = array index, consistent with how **PowerSupplies** and **PowerControl** are labeled in the same function.

- BMCs that only expose the modern **Sensors** collection (no legacy Power resource) simply don't emit the metric — **RefreshPowerOld** never runs for them. Supporting that path (e.g. via **$expand**) is deliberately out of scope per the issue discussion.

Tested by building this branch and scraping live Lenovo XCC hosts (firmware AFBT44K 4.30): the four voltage series appear with correct values on a healthy host and the failing coin cell reads 0.27 V; all existing power metrics unchanged.